### PR TITLE
add missing define to allow building of RUI3 under Og optimisation

### DIFF
--- a/variants/WisCore_RAK11720_Board/gpio-board.c
+++ b/variants/WisCore_RAK11720_Board/gpio-board.c
@@ -26,6 +26,8 @@
 #include "rtc-board.h"
 #include "gpio-board.h"
 #include "udrv_gpio.h"
+#include "error_check.h"
+#define assert_param ASSERT
 
 void GpioMcuInit( Gpio_t *obj, PinNames pin, PinModes mode, PinConfigs config, PinTypes type, uint32_t value )
 {


### PR DESCRIPTION
Currently if RUI3 is built under 0g optimisation, `gpio-board.c` fails to compile because of a missing define for `assert_param`

I've added this define (similar to how it works in [spi-board.c](https://github.com/RAKWireless/RAK-APOLLO3-RUI/blob/55e008068ce686857a638bfdc02c853b9a22d639/variants/WisCore_RAK11720_Board/spi-board.c#L30-L33)) and it is now working.